### PR TITLE
Added port number to signed URL

### DIFF
--- a/AWSWebSocketClient.cpp
+++ b/AWSWebSocketClient.cpp
@@ -137,7 +137,7 @@ char* AWSWebSocketClient::getCurrentTime(void) {
 }
 
 //generate AWS url path, signed using url parameters
-char* AWSWebSocketClient::generateAWSPath () {
+char* AWSWebSocketClient::generateAWSPath (uint16_t port) {
 
 	 
     char* dateTime = getCurrentTime ();
@@ -168,7 +168,7 @@ char* AWSWebSocketClient::generateAWSPath () {
 	sprintf(canonicalQuerystring, "%s&X-Amz-SignedHeaders=host", canonicalQuerystring);
 
 	char* canonicalHeaders = new char[strlen (awsDomain)+7]();
-	sprintf(canonicalHeaders, "%shost:%s\n", canonicalHeaders,awsDomain);
+	sprintf(canonicalHeaders, "%shost:%s:%d\n", canonicalHeaders,awsDomain,port);
 	SHA256* sha256 = new SHA256();
 	char* payloadHash = (*sha256)("", 0);
 	delete sha256;
@@ -281,7 +281,7 @@ int AWSWebSocketClient::connect(const char *host, uint16_t port) {
 	  bool freePath = false;
 	  if (this->path == NULL) {
 		  //just generate AWS Path if user does not inform its own (to support the lib usage out of aws)
-		  path = generateAWSPath ();
+		  path = generateAWSPath (port);
 		  freePath = true;
 	  }
 	  if (useSSL == true)

--- a/AWSWebSocketClient.cpp
+++ b/AWSWebSocketClient.cpp
@@ -167,8 +167,10 @@ char* AWSWebSocketClient::generateAWSPath (uint16_t port) {
 	sprintf(canonicalQuerystring, "%s&X-Amz-Expires=86400", canonicalQuerystring); //sign will last one day
 	sprintf(canonicalQuerystring, "%s&X-Amz-SignedHeaders=host", canonicalQuerystring);
 
-	char* canonicalHeaders = new char[strlen (awsDomain)+7]();
-	sprintf(canonicalHeaders, "%shost:%s:%d\n", canonicalHeaders,awsDomain,port);
+	String portString = String(port);
+	char* canonicalHeaders = new char[strlen (awsDomain)+ strlen (portString.c_str())+ 7]();
+
+	sprintf(canonicalHeaders, "%shost:%s:%s\n", canonicalHeaders,awsDomain,portString.c_str());
 	SHA256* sha256 = new SHA256();
 	char* payloadHash = (*sha256)("", 0);
 	delete sha256;

--- a/AWSWebSocketClient.h
+++ b/AWSWebSocketClient.h
@@ -56,7 +56,7 @@ public:
       
   protected:
   //generate AWS signed path
-  char* generateAWSPath ();
+  char* generateAWSPath (uint16_t port);
   
   //convert the month info
   String getMonth(String sM);


### PR DESCRIPTION
arduinoWebSockets added the port to their Host header.
Since the signature signs this Host header it needs to contain this port also.

Fixes #9. Potentially also some of the other issues.