### PR TITLE
Revert "changed AWSWebSocketClient signature for flush and stop to work with …"

### DIFF
--- a/AWSWebSocketClient.cpp
+++ b/AWSWebSocketClient.cpp
@@ -498,19 +498,17 @@ int AWSWebSocketClient::peek() {
 	return bb.peek ();
 }
 
-bool AWSWebSocketClient::flush(unsigned int maxWaitMs) {
-    return true;
+void AWSWebSocketClient::flush() {
+
 }
 
-bool AWSWebSocketClient::stop(unsigned int maxWaitMs) {
+void AWSWebSocketClient::stop() {
 	if (_connected == true) {		
 		_connected = false;		
 	}
     bb.clear ();
 	clientDisconnect(&_client);
 	//disconnect ();
-
-    return true;
 }
 
 uint8_t AWSWebSocketClient::connected() {

--- a/AWSWebSocketClient.h
+++ b/AWSWebSocketClient.h
@@ -30,8 +30,6 @@ public:
   ~AWSWebSocketClient();
 
   
-  bool stop(unsigned int maxWaitMs = 0);
-  bool flush(unsigned int maxWaitMs = 0);
 
   int connect(IPAddress ip, uint16_t port);
   int connect(const char *host, uint16_t port);
@@ -44,6 +42,8 @@ public:
   int read(uint8_t *buf, size_t size);
 
   int peek();
+  void flush();
+  void stop();
   uint8_t connected() ;
   operator bool();
 


### PR DESCRIPTION
Reverts odelot/aws-mqtt-websockets#53 

temporary reverts the pull request to test its compatibility with esp8266 sdk 2.5.0